### PR TITLE
add in get_total_size_bytes() for TriggerRecord

### DIFF
--- a/include/daqdataformats/TriggerRecord.hpp
+++ b/include/daqdataformats/TriggerRecord.hpp
@@ -80,6 +80,19 @@ public:
    */
   void add_fragment(std::unique_ptr<Fragment>&& fragment) { m_fragments.emplace_back(std::move(fragment)); }
 
+  /**
+   * @brief Get size of trigger record from underlying TriggerRecordHeader and Fragments
+   */
+  size_t get_total_size_bytes() const
+  {
+    size_t total_size=get_header_ref().get_total_size_bytes();
+    
+    for(auto const& frag_ptr : m_fragments)
+      total_size += frag_ptr->get_size();
+
+    return total_size;
+  }
+
 private:
   TriggerRecordHeader m_header;                       ///< TriggerRecordHeader object
   std::vector<std::unique_ptr<Fragment>> m_fragments; ///< Vector of unique_ptrs to Fragment objects


### PR DESCRIPTION
Adds new member for diving through the TriggerRecord and calculating the total size in bytes.

Admittedly, I _think_ this is correct, but I'd really like an extra set of eyes to be sure that this would indeed return the total size in bytes of the trigger record header data and fragments, as would be seen/written into a file.