### PR TITLE
add comparison for GeoID to pybind, and add a kinder print statement …

### DIFF
--- a/pybindsrc/geoid.cpp
+++ b/pybindsrc/geoid.cpp
@@ -10,6 +10,9 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/operators.h>
+
+#include <sstream>
 
 namespace py = pybind11;
 
@@ -22,6 +25,13 @@ register_geoid(py::module& m)
 {
 
   py::class_<GeoID> py_geoid(m, "GeoID");
+  py_geoid.def(py::self < py::self)
+          .def("__repr__",
+               [](const GeoID &gid){
+                 std::ostringstream oss;
+                 oss << "<daqdataformats::GeoID " << gid << ">";
+                 return oss.str();
+               });
 
   py::enum_<GeoID::SystemType>(py_geoid, "SystemType")
     .value("kTPC", GeoID::SystemType::kTPC)


### PR DESCRIPTION
…for GeoIDs

Needed for https://github.com/DUNE-DAQ/hdf5libs/issues/11.

Should be merged onto v2.10.1


