### PR TITLE
Add static_assert(offsetof()) calls for all dataformat members. 

### DIFF
--- a/docs/FragmentHeaderV3.md
+++ b/docs/FragmentHeaderV3.md
@@ -39,11 +39,11 @@ using sequence_number_t = uint16_t;
 
 struct FragmentHeader
 {
-  static constexpr uint32_t s_fragment_header_magic = 0x11112222;
+  static constexpr uint32_t s_fragment_header_marker = 0x11112222;
   static constexpr uint32_t s_fragment_header_version = 3;
   static constexpr uint32_t s_default_error_bits = 0;
 
-  uint32_t fragment_header_marker = s_fragment_header_magic;
+  uint32_t fragment_header_marker = s_fragment_header_marker;
   uint32_t version = s_fragment_header_version;
   fragment_size_t size{ TypeDefaults::s_invalid_fragment_size };
   trigger_number_t trigger_number{ TypeDefaults::s_invalid_trigger_number };

--- a/docs/TriggerRecordHeaderDataV2.md
+++ b/docs/TriggerRecordHeaderDataV2.md
@@ -32,12 +32,12 @@ using sequence_number_t = uint16_t;
 struct TriggerRecordHeaderData
 {
   
-  static constexpr uint32_t s_trigger_record_header_magic = 0x33334444;
+  static constexpr uint32_t s_trigger_record_header_marker = 0x33334444;
   static constexpr uint32_t s_trigger_record_header_version = 2;
   static constexpr uint64_t s_invalid_number_components = std::numeric_limits<uint64_t>::max();
   static constexpr uint32_t s_default_error_bits = 0;
 
-  uint32_t trigger_record_header_marker = s_trigger_record_header_magic;
+  uint32_t trigger_record_header_marker = s_trigger_record_header_marker;
   uint32_t version = s_trigger_record_header_version;
   trigger_number_t trigger_number{ TypeDefaults::s_invalid_trigger_number };
   timestamp_t trigger_timestamp{ TypeDefaults::s_invalid_timestamp };

--- a/include/daqdataformats/ComponentRequest.hpp
+++ b/include/daqdataformats/ComponentRequest.hpp
@@ -12,6 +12,7 @@
 #include "daqdataformats/GeoID.hpp"
 #include "daqdataformats/Types.hpp"
 
+#include <cstddef>
 #include <ostream>
 #include <string>
 
@@ -50,6 +51,12 @@ struct ComponentRequest
   inline ComponentRequest(GeoID const& comp, timestamp_t const& wbegin, timestamp_t const& wend);
 };
 static_assert(sizeof(ComponentRequest) == 40, "ComponentRequest struct size different than expected!");
+static_assert(offsetof(ComponentRequest, version) == 0, "ComponentRequest version field not at expected offset");
+static_assert(offsetof(ComponentRequest, unused) == 4, "ComponentRequest unused field not at expected offset");
+static_assert(offsetof(ComponentRequest, component) == 8, "ComponentRequest component field not at expected offset");
+static_assert(offsetof(ComponentRequest, window_begin) == 24,
+              "ComponentRequest window_begin field not at expected offset");
+static_assert(offsetof(ComponentRequest, window_end) == 32, "ComponentRequest window_end field not at expected offset");
 
 /**
  * @brief Write out a ComponentRequest in human-readable form

--- a/include/daqdataformats/FragmentHeader.hpp
+++ b/include/daqdataformats/FragmentHeader.hpp
@@ -13,6 +13,7 @@
 #include "daqdataformats/Types.hpp"
 
 #include <bitset>
+#include <cstddef>
 #include <cstdlib>
 #include <map>
 #include <numeric>
@@ -29,9 +30,9 @@ namespace daqdataformats {
 struct FragmentHeader
 {
   /**
-   * @brief Magic bytes to identify a FragmentHeader entry in a raw data stream
+   * @brief Marker bytes to identify a FragmentHeader entry in a raw data stream
    */
-  static constexpr uint32_t s_fragment_header_magic = 0x11112222; // NOLINT(build/unsigned)
+  static constexpr uint32_t s_fragment_header_marker = 0x11112222; // NOLINT(build/unsigned)
 
   /**
    * @brief The current version of the Fragment
@@ -44,9 +45,9 @@ struct FragmentHeader
   static constexpr uint32_t s_default_error_bits = 0; // NOLINT(build/unsigned)
 
   /**
-   * @brief Magic Bytes used to identify FragmentHeaders in a raw data stream
+   * @brief Marker Bytes used to identify FragmentHeaders in a raw data stream
    */
-  uint32_t fragment_header_marker = s_fragment_header_magic; // NOLINT(build/unsigned)
+  uint32_t fragment_header_marker = s_fragment_header_marker; // NOLINT(build/unsigned)
 
   /**
    * @brief Version of the FragmentHeader
@@ -109,6 +110,25 @@ struct FragmentHeader
   GeoID element_id;
 };
 static_assert(sizeof(FragmentHeader) == 80, "FragmentHeader struct size different than expected!");
+static_assert(offsetof(FragmentHeader, fragment_header_marker) == 0,
+              "FragmentHeader fragment_header_marker field not at expected offset!");
+static_assert(offsetof(FragmentHeader, version) == 4, "FragmentHeader version field not at expected offset!");
+static_assert(offsetof(FragmentHeader, size) == 8, "FragmentHeader size field not at expected offset!");
+static_assert(offsetof(FragmentHeader, trigger_number) == 16,
+              "FragmentHeader trigger_number field not at expected offset!");
+static_assert(offsetof(FragmentHeader, trigger_timestamp) == 24,
+              "FragmentHeader trigger_timestamp field not at expected offset!");
+static_assert(offsetof(FragmentHeader, window_begin) == 32,
+              "FragmentHeader window_begin field not at expected offset!");
+static_assert(offsetof(FragmentHeader, window_end) == 40, "FragmentHeader window_end field not at expected offset!");
+static_assert(offsetof(FragmentHeader, run_number) == 48, "FragmentHeader run_number field not at expected offset!");
+static_assert(offsetof(FragmentHeader, error_bits) == 52, "FragmentHeader error_bits field not at expected offset!");
+static_assert(offsetof(FragmentHeader, fragment_type) == 56,
+              "FragmentHeader fragment_type field not at expected offset!");
+static_assert(offsetof(FragmentHeader, sequence_number) == 60,
+              "FragmentHeader sequence_number field not at expected offset!");
+static_assert(offsetof(FragmentHeader, unused) == 62, "FragmentHeader unused field not at expected offset!");
+static_assert(offsetof(FragmentHeader, element_id) == 64, "FragmentHeader element_id field not at expected offset!");
 
 /**
  * @brief This enumeration should list all defined error bits, as well as a short documentation of their meaning

--- a/include/daqdataformats/GeoID.hpp
+++ b/include/daqdataformats/GeoID.hpp
@@ -9,6 +9,7 @@
 #ifndef DAQDATAFORMATS_INCLUDE_DAQDATAFORMATS_GEOID_HPP_
 #define DAQDATAFORMATS_INCLUDE_DAQDATAFORMATS_GEOID_HPP_
 
+#include <cstddef>
 #include <cstdint>
 #include <istream>
 #include <limits>
@@ -97,6 +98,11 @@ struct GeoID
 };
 
 static_assert(sizeof(GeoID) == 16, "GeoID struct size different than expected!");
+static_assert(offsetof(GeoID, version) == 0, "GeoID version field not at expected offset");
+static_assert(offsetof(GeoID, system_type) == 4, "GeoID system_type field not at expected offset");
+static_assert(offsetof(GeoID, region_id) == 6, "GeoID region_id field not at expected offset");
+static_assert(offsetof(GeoID, element_id) == 8, "GeoID element_id field not at expected offset");
+static_assert(offsetof(GeoID, unused) == 12, "GeoID unused field not at expected offset");
 
 /**
  * @brief Stream a SystemType instance in a human-readable form

--- a/include/daqdataformats/TimeSliceHeader.hpp
+++ b/include/daqdataformats/TimeSliceHeader.hpp
@@ -12,6 +12,7 @@
 #include "daqdataformats/ComponentRequest.hpp"
 #include "daqdataformats/Types.hpp"
 
+#include <cstddef>
 #include <limits>
 #include <ostream>
 #include <string>
@@ -27,9 +28,9 @@ namespace daqdataformats {
 struct TimeSliceHeader
 {
   /**
-   * @brief Magic bytes to identify a TimeSliceHeader entry in a raw data stream
+   * @brief Marker bytes to identify a TimeSliceHeader entry in a raw data stream
    */
-  static constexpr uint32_t s_timeslice_header_magic = 0x55556666; // NOLINT(build/unsigned)
+  static constexpr uint32_t s_timeslice_header_marker = 0x55556666; // NOLINT(build/unsigned)
 
   /**
    * @brief The current version of the TimeSliceHeader
@@ -37,9 +38,9 @@ struct TimeSliceHeader
   static constexpr uint32_t s_timeslice_header_version = 1; // NOLINT(build/unsigned)
 
   /**
-   * @brief Magic bytes used to identify a TimeSliceHeader struct in a raw data stream
+   * @brief Marker bytes used to identify a TimeSliceHeader struct in a raw data stream
    */
-  uint32_t timeslice_header_marker = s_timeslice_header_magic; // NOLINT(build/unsigned)
+  uint32_t timeslice_header_marker = s_timeslice_header_marker; // NOLINT(build/unsigned)
 
   /**
    * @brief Version of the TimeSliceHeader structure
@@ -62,6 +63,13 @@ struct TimeSliceHeader
   uint32_t unused{ 0xFFFFFFFF }; // NOLINT(build/unsigned)
 };
 static_assert(sizeof(TimeSliceHeader) == 24, "TimeSliceHeader struct size different than expected!");
+static_assert(offsetof(TimeSliceHeader, timeslice_header_marker) == 0,
+              "TimeSliceHeader timeslice_header_marker field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, version) == 4, "TimeSliceHeader version field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, timeslice_number) == 8,
+              "TimeSliceHeader timeslice_number field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, run_number) == 16, "TimeSliceHeader run_number field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, unused) == 20, "TimeSliceHeader unused field not at expected offset!");
 
 /**
  * @brief Stream a TimeSliceHeader instance in human-readable form

--- a/include/daqdataformats/TriggerRecordHeader.hpp
+++ b/include/daqdataformats/TriggerRecordHeader.hpp
@@ -14,6 +14,7 @@
 #include "daqdataformats/Types.hpp"
 
 #include <bitset>
+#include <cstddef>
 #include <cstring>
 #include <new>
 #include <ostream>

--- a/include/daqdataformats/TriggerRecordHeaderData.hpp
+++ b/include/daqdataformats/TriggerRecordHeaderData.hpp
@@ -12,6 +12,7 @@
 #include "daqdataformats/ComponentRequest.hpp"
 #include "daqdataformats/Types.hpp"
 
+#include <cstddef>
 #include <limits>
 #include <ostream>
 #include <string>
@@ -102,6 +103,28 @@ struct TriggerRecordHeaderData
   uint16_t unused{ 0xFFFF }; // NOLINT(build/unsigned)
 };
 static_assert(sizeof(TriggerRecordHeaderData) == 48, "TriggerRecordHeaderData struct size different than expected!");
+static_assert(offsetof(TriggerRecordHeaderData, trigger_record_header_marker) == 0,
+              "TriggerRecordHeaderData trigger_record_header_marker field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, version) == 4,
+              "TriggerRecordHeaderData version field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, trigger_number) == 8,
+              "TriggerRecordHeaderData trigger_number field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, trigger_timestamp) == 16,
+              "TriggerRecordHeaderData trigger_timestamp field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, num_requested_components) == 24,
+              "TriggerRecordHeaderData num_requested_components field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, run_number) == 32,
+              "TriggerRecordHeaderData run_number field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, error_bits) == 36,
+              "TriggerRecordHeaderData error_bits field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, trigger_type) == 40,
+              "TriggerRecordHeaderData trigger_type field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, sequence_number) == 42,
+              "TriggerRecordHeaderData sequence_number field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, max_sequence_number) == 44,
+              "TriggerRecordHeaderData max_sequence_number field not at expected offset!");
+static_assert(offsetof(TriggerRecordHeaderData, unused) == 46,
+              "TriggerRecordHeaderData unused field not at expected offset!");
 
 /**
  * @brief This enumeration should list all defined error bits, as well as a short documentation of their meaning

--- a/pybindsrc/geoid.cpp
+++ b/pybindsrc/geoid.cpp
@@ -8,9 +8,9 @@
 
 #include "daqdataformats/GeoID.hpp"
 
+#include <pybind11/operators.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include <pybind11/operators.h>
 
 #include <sstream>
 
@@ -25,13 +25,11 @@ register_geoid(py::module& m)
 {
 
   py::class_<GeoID> py_geoid(m, "GeoID");
-  py_geoid.def(py::self < py::self)
-          .def("__repr__",
-               [](const GeoID &gid){
-                 std::ostringstream oss;
-                 oss << "<daqdataformats::GeoID " << gid << ">";
-                 return oss.str();
-               });
+  py_geoid.def(py::self < py::self).def("__repr__", [](const GeoID& gid) {
+    std::ostringstream oss;
+    oss << "<daqdataformats::GeoID " << gid << ">";
+    return oss.str();
+  });
 
   py::enum_<GeoID::SystemType>(py_geoid, "SystemType")
     .value("kTPC", GeoID::SystemType::kTPC)

--- a/pybindsrc/time_slice.cpp
+++ b/pybindsrc/time_slice.cpp
@@ -25,9 +25,9 @@ void
 register_timeslice(py::module& m)
 {
   py::class_<TimeSliceHeader>(m, "TimeSliceHeader")
-    .def_property_readonly_static("s_timeslice_header_magic",
+    .def_property_readonly_static("s_timeslice_header_marker",
                                   [](const TimeSliceHeader& self) -> uint32_t { // NOLINT(build/unsigned)
-                                    return self.s_timeslice_header_magic;
+                                    return self.s_timeslice_header_marker;
                                   })
     .def_property_readonly_static("s_timeslice_header_version",
                                   [](const TimeSliceHeader& self) -> uint32_t { // NOLINT(build/unsigned)


### PR DESCRIPTION
Rename static "magic" variables (no side-effects in dfmessages, dfmodules, or trigger).

Resolves #25 