### PR TITLE
New Fragment convenience method to retrieve the data size 

### DIFF
--- a/include/daqdataformats/Fragment.hpp
+++ b/include/daqdataformats/Fragment.hpp
@@ -240,6 +240,13 @@ public:
    * @return The size of the Fragment, including header and all payload pieces
    */
   fragment_size_t get_size() const { return header_()->size; }
+
+  /**
+   * @brief Get the size of the Fragment data
+   * @return The size of the Fragment data, payload only
+   */
+  fragment_size_t get_data_size() const { return header_()->size-sizeof(FragmentHeader); }
+
   /**
    * @brief Get a pointer to the data payload in the Fragmnet
    * @return Pointer to the data payload in the Fragment

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -39,11 +39,18 @@ register_fragment(py::module& m)
     .def("get_fragment_type", &Fragment::get_fragment_type)
     .def("get_sequence_number", &Fragment::get_sequence_number)
     .def("get_size", &Fragment::get_size)
+    .def("get_data_size", &Fragment::get_data_size)
     .def("get_data", &Fragment::get_data, py::return_value_policy::reference_internal)
     .def(
       "get_data",
       [](Fragment& self, size_t offset) { return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); },
-      py::return_value_policy::reference_internal);
+      py::return_value_policy::reference_internal  
+    )
+    .def("get_data_bytes", [](Fragment* fr) -> py::bytes {
+           return py::bytes(reinterpret_cast<char*>(fr->get_data()), fr->get_size()-sizeof(FragmentHeader));
+        },
+        py::return_value_policy::reference_internal
+    );
 
   py::enum_<Fragment::BufferAdoptionMode>(py_fragment, "BufferAdoptionMode")
     .value("kReadOnlyMode", Fragment::BufferAdoptionMode::kReadOnlyMode)

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -47,7 +47,7 @@ register_fragment(py::module& m)
       py::return_value_policy::reference_internal  
     )
     .def("get_data_bytes", [](Fragment* fr) -> py::bytes {
-           return py::bytes(reinterpret_cast<char*>(fr->get_data()), fr->get_size()-sizeof(FragmentHeader));
+           return py::bytes(reinterpret_cast<char*>(fr->get_data()), fr->get_data_size());
         },
         py::return_value_policy::reference_internal
     );


### PR DESCRIPTION
This PR adds a convenience method to directly retrieve the fragment data size, thus avoiding explicitly re-calculating every time as fragment size - header size. 