### PR TITLE
python bindings: improving data accessors

### DIFF
--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -42,20 +42,22 @@ register_fragment(py::module& m)
     .def("get_size", &Fragment::get_size)
     .def("get_data_size", &Fragment::get_data_size)
     .def(
-      "get_data",
-      [](Fragment& self, size_t offset) { return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); },
-      "offset"_a=0,
-      py::return_value_policy::reference_internal  
-    )
-    .def("get_data_bytes", [](Fragment* self, size_t offset) -> py::bytes {
-          if (offset > self->get_data_size()) {
-            throw std::runtime_error("Fragment.get_data_bytes: offset exceeds fragment size.");
-          }
-          return py::bytes(reinterpret_cast<char*>(self->get_data())+offset, self->get_data_size()-offset);
+      "get_data", [](Fragment& self, size_t offset) { return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); }, "offset"_a = 0, py::return_value_policy::reference_internal)
+    .def(
+      "get_data_bytes",
+      [](Fragment* self, size_t offset) -> py::bytes {
+        // std::cout << "Frag size: " << self->get_data_size() << " data offset " << offset << std::endl;
+        // std::cout << "Bytes size: " << bytes_size << std::endl;
+
+
+        if (offset > self->get_data_size()) {
+          throw std::runtime_error("Fragment.get_data_bytes: offset exceeds fragment size.");
+        }
+        size_t bytes_size = self->get_data_size() - offset;
+        return py::bytes(reinterpret_cast<char*>(self->get_data()) + offset, bytes_size);
       },
-      "offset"_a=0,
-      py::return_value_policy::reference_internal
-    );
+      "offset"_a = 0,
+      py::return_value_policy::reference_internal);
 
   py::enum_<Fragment::BufferAdoptionMode>(py_fragment, "BufferAdoptionMode")
     .value("kReadOnlyMode", Fragment::BufferAdoptionMode::kReadOnlyMode)

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -46,10 +46,6 @@ register_fragment(py::module& m)
     .def(
       "get_data_bytes",
       [](Fragment* self, size_t offset) -> py::bytes {
-        // std::cout << "Frag size: " << self->get_data_size() << " data offset " << offset << std::endl;
-        // std::cout << "Bytes size: " << bytes_size << std::endl;
-
-
         if (offset > self->get_data_size()) {
           throw std::runtime_error("Fragment.get_data_bytes: offset exceeds fragment size.");
         }

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -41,11 +41,10 @@ register_fragment(py::module& m)
     .def("get_sequence_number", &Fragment::get_sequence_number)
     .def("get_size", &Fragment::get_size)
     .def("get_data_size", &Fragment::get_data_size)
-    // .def("get_data", &Fragment::get_data, py::return_value_policy::reference_internal)
     .def(
       "get_data",
       [](Fragment& self, size_t offset) { return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); },
-      "self"_a, "offset"_a=0,
+      "offset"_a=0,
       py::return_value_policy::reference_internal  
     )
     .def("get_data_bytes", [](Fragment* self, size_t offset) -> py::bytes {
@@ -54,7 +53,7 @@ register_fragment(py::module& m)
           }
           return py::bytes(reinterpret_cast<char*>(self->get_data())+offset, self->get_data_size()-offset);
       },
-      "self"_a, "offset"_a=0,
+      "offset"_a=0,
       py::return_value_policy::reference_internal
     );
 

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -13,6 +13,7 @@
 #include <pybind11/stl.h>
 
 namespace py = pybind11;
+using namespace pybind11::literals; // to bring in the `_a` literal
 
 namespace dunedaq {
 namespace daqdataformats {
@@ -40,16 +41,21 @@ register_fragment(py::module& m)
     .def("get_sequence_number", &Fragment::get_sequence_number)
     .def("get_size", &Fragment::get_size)
     .def("get_data_size", &Fragment::get_data_size)
-    .def("get_data", &Fragment::get_data, py::return_value_policy::reference_internal)
+    // .def("get_data", &Fragment::get_data, py::return_value_policy::reference_internal)
     .def(
       "get_data",
       [](Fragment& self, size_t offset) { return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); },
+      "self"_a, "offset"_a=0,
       py::return_value_policy::reference_internal  
     )
-    .def("get_data_bytes", [](Fragment* fr) -> py::bytes {
-           return py::bytes(reinterpret_cast<char*>(fr->get_data()), fr->get_data_size());
-        },
-        py::return_value_policy::reference_internal
+    .def("get_data_bytes", [](Fragment* self, size_t offset) -> py::bytes {
+          if (offset > self->get_data_size()) {
+            throw std::runtime_error("Fragment.get_data_bytes: offset exceeds fragment size.");
+          }
+          return py::bytes(reinterpret_cast<char*>(self->get_data())+offset, self->get_data_size()-offset);
+      },
+      "self"_a, "offset"_a=0,
+      py::return_value_policy::reference_internal
     );
 
   py::enum_<Fragment::BufferAdoptionMode>(py_fragment, "BufferAdoptionMode")


### PR DESCRIPTION
Adding default offset (`0`) to fragment's `get_data` and adding `py::bytes` getter (`get_data_bytes`)