### PR TITLE
Added a get_component_for_source_id method to TriggerRecordHeader

### DIFF
--- a/include/daqdataformats/TriggerRecordHeader.hpp
+++ b/include/daqdataformats/TriggerRecordHeader.hpp
@@ -231,6 +231,14 @@ public:
    */
   inline ComponentRequest& operator[](size_t idx);
 
+  /**
+   * @brief Access ComponentRequest by SourceID
+   * @param source_id SourceID to access
+   * @return ComponentRequest constant reference
+   * @throws std::invalid_argument exception if source_id is not in ComponentRequest list
+   */
+  inline ComponentRequest const& get_component_for_source_id(SourceID const& source_id) const;
+
 private:
   /**
    * @brief Get the TriggerRecordHeaderData from the m_data_arr array
@@ -324,6 +332,18 @@ TriggerRecordHeader::operator[](size_t idx)
   }
   // Increment header pointer by one to skip header
   return *(reinterpret_cast<ComponentRequest*>(header_() + 1) + idx); // NOLINT
+}
+
+ComponentRequest const&
+TriggerRecordHeader::get_component_for_source_id(SourceID const& source_id) const
+{
+  for (uint64_t idx = 0; idx < get_num_requested_components(); ++idx) {
+    ComponentRequest const& component_obj = *(reinterpret_cast<ComponentRequest*>(header_() + 1) + idx); // NOLINT
+    if (source_id == component_obj.component) {
+      return component_obj;
+    }
+  }
+  throw std::invalid_argument("Supplied SourceID was not found in the ComponentRequest list.");
 }
 
 } // namespace dunedaq::daqdataformats

--- a/include/daqdataformats/TriggerRecordHeader.hpp
+++ b/include/daqdataformats/TriggerRecordHeader.hpp
@@ -343,7 +343,7 @@ TriggerRecordHeader::get_component_for_source_id(SourceID const& source_id) cons
       return component_obj;
     }
   }
-  throw std::invalid_argument("Supplied SourceID was not found in the ComponentRequest list.");
+  throw std::invalid_argument("Supplied SourceID (" + source_id.to_string() + ") was not found in the ComponentRequest list.");
 }
 
 } // namespace dunedaq::daqdataformats

--- a/unittest/TriggerRecordHeader_test.cxx
+++ b/unittest/TriggerRecordHeader_test.cxx
@@ -222,9 +222,21 @@ BOOST_AUTO_TEST_CASE(HeaderFields)
   components.back().window_begin = 3;
   components.back().window_end = 4;
   components.emplace_back();
+  components.back().component = { SourceID::Subsystem::kDetectorReadout, 34 };
+  components.back().window_begin = 5;
+  components.back().window_end = 6;
+  components.emplace_back();
   components.back().component = { SourceID::Subsystem::kDetectorReadout, 56 };
   components.back().window_begin = 7;
   components.back().window_end = 8;
+  components.emplace_back();
+  components.back().component = { SourceID::Subsystem::kDetectorReadout, 78 };
+  components.back().window_begin = 9;
+  components.back().window_end = 10;
+  components.emplace_back();
+  components.back().component = { SourceID::Subsystem::kDetectorReadout, 90 };
+  components.back().window_begin = 11;
+  components.back().window_end = 12;
 
   auto header = new TriggerRecordHeader(components);
   header->set_run_number(9);
@@ -243,9 +255,25 @@ BOOST_AUTO_TEST_CASE(HeaderFields)
   BOOST_REQUIRE_EQUAL(header->get_trigger_type(), header_data.trigger_type);
   BOOST_REQUIRE_EQUAL(header->get_sequence_number(), header_data.sequence_number);
   BOOST_REQUIRE_EQUAL(header->get_max_sequence_number(), header_data.max_sequence_number);
-  BOOST_REQUIRE_EQUAL(header->get_num_requested_components(), 2);
+  BOOST_REQUIRE_EQUAL(header->get_num_requested_components(), 5);
   BOOST_REQUIRE_EQUAL(header->get_num_requested_components(), header_data.num_requested_components);
   BOOST_REQUIRE_EQUAL(header->get_error_bits().to_ulong(), 0x80000002);
+
+  auto comp_ref = header->get_component_for_source_id({ SourceID::Subsystem::kDetectorReadout, 78 });
+  BOOST_REQUIRE_EQUAL(comp_ref.window_begin, 9);
+  BOOST_REQUIRE_EQUAL(comp_ref.window_end, 10);
+  comp_ref = header->get_component_for_source_id({ SourceID::Subsystem::kDetectorReadout, 56 });
+  BOOST_REQUIRE_EQUAL(comp_ref.window_begin, 7);
+  BOOST_REQUIRE_EQUAL(comp_ref.window_end, 8);
+  comp_ref = header->get_component_for_source_id({ SourceID::Subsystem::kDetectorReadout, 12 });
+  BOOST_REQUIRE_EQUAL(comp_ref.window_begin, 3);
+  BOOST_REQUIRE_EQUAL(comp_ref.window_end, 4);
+  comp_ref = header->get_component_for_source_id({ SourceID::Subsystem::kDetectorReadout, 90 });
+  BOOST_REQUIRE_EQUAL(comp_ref.window_begin, 11);
+  BOOST_REQUIRE_EQUAL(comp_ref.window_end, 12);
+  BOOST_REQUIRE_EXCEPTION(header->get_component_for_source_id({ SourceID::Subsystem::kDetectorReadout, 43 }),
+                          std::invalid_argument,
+                          [&](std::invalid_argument) { return true; });
 
   auto header_ptr = static_cast<const TriggerRecordHeaderData*>(header->get_storage_location());
   BOOST_REQUIRE_EQUAL(header_ptr->run_number, header_data.run_number);


### PR DESCRIPTION
… to provide easier lookup for data inspection tools.

This functionality was added as part of adding extra output to the HDF5Libs_TestDumpRecord app (in the hdf5libs repo), and all of that was part of testing the MLT readout map rework.  The relevant PR in hdf5libs is [here](https://github.com/DUNE-DAQ/hdf5libs/pull/66).

This PR can be tested and merged independently of any other changes, but it is needed for the subsequent change in hdf5libs.