### PR TITLE
ProtoDUNE CRT integration

### DIFF
--- a/include/daqdataformats/FragmentHeader.hpp
+++ b/include/daqdataformats/FragmentHeader.hpp
@@ -210,7 +210,8 @@ enum class FragmentType : fragment_type_t
   kPACMAN = 10,
   kMPD = 11,
   kWIBEth = 12,
-  kDAPHNEStream = 13
+  kDAPHNEStream = 13,
+  kCRT = 14
 };
 
 /**
@@ -236,6 +237,7 @@ get_fragment_type_names()
     { FragmentType::kPACMAN, "PACMAN"},
     { FragmentType::kMPD, "MPD"},
     { FragmentType::kWIBEth, "WIBEth"},
+    { FragmentType::kCRT, "CRT"},
   };
 }
 

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -106,6 +106,7 @@ register_fragment(py::module& m)
     .value("kPACMAN", FragmentType::kPACMAN)
     .value("kWIBEth", FragmentType::kWIBEth)
     .value("kDAPHNEStream", FragmentType::kDAPHNEStream)
+    .value("kCRT", FragmentType::kCRT)
     .export_values();
 }
 


### PR DESCRIPTION
Adding a CRT fragment type to support CRT integration with the DAQ.

Associated pull requests are made for the `mmatt15/crt` branches in [fddetdataformats](https://github.com/DUNE-DAQ/fddetdataformats/pull/16), [fdreadoutlibs](https://github.com/DUNE-DAQ/fdreadoutlibs/pull/162), [fdreadoutmodules](https://github.com/DUNE-DAQ/fdreadoutmodules/pull/14), [fddaqconf](https://github.com/DUNE-DAQ/fddaqconf/pull/24), and [rawdatautils](https://github.com/DUNE-DAQ/rawdatautils/pull/52).