### PR TITLE
Merging v4 changes into the v5 line.  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.12)
-project(daqdataformats VERSION 3.7.0)
+project(daqdataformats VERSION 3.7.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/daqdataformats/TimeSlice.hpp
+++ b/include/daqdataformats/TimeSlice.hpp
@@ -80,7 +80,7 @@ public:
   void set_element_id(SourceID source_id) { m_header.element_id = source_id; }
 
   /**
-   * @brief Get size of trigger record from underlying TriggerRecordHeader and Fragments
+   * @brief Get size of timeslice from underlying TimeSliceHeader and Fragments
    */
   size_t get_total_size_bytes() const
   {
@@ -88,6 +88,19 @@ public:
 
     for (auto const& frag_ptr : m_fragments)
       total_size += frag_ptr->get_size();
+
+    return total_size;
+  }
+
+  /**
+   * @brief Get the sum of the fragment payload sizes
+   */
+  size_t get_sum_of_fragment_payload_sizes() const
+  {
+    size_t total_size = 0;
+
+    for (auto const& frag_ptr : m_fragments)
+      total_size += frag_ptr->get_data_size();
 
     return total_size;
   }

--- a/include/daqdataformats/TriggerRecord.hpp
+++ b/include/daqdataformats/TriggerRecord.hpp
@@ -92,6 +92,19 @@ public:
     return total_size;
   }
 
+  /**
+   * @brief Get the sum of the fragment payload sizes
+   */
+  size_t get_sum_of_fragment_payload_sizes() const
+  {
+    size_t total_size = 0;
+
+    for (auto const& frag_ptr : m_fragments)
+      total_size += frag_ptr->get_data_size();
+
+    return total_size;
+  }
+
 private:
   TriggerRecordHeader m_header;                       ///< TriggerRecordHeader object
   std::vector<std::unique_ptr<Fragment>> m_fragments; ///< Vector of unique_ptrs to Fragment objects

--- a/pybindsrc/time_slice.cpp
+++ b/pybindsrc/time_slice.cpp
@@ -60,7 +60,9 @@ register_timeslice(py::module& m)
         }
         return fragments;
       },
-      py::return_value_policy::reference_internal);
+      py::return_value_policy::reference_internal)
+    .def("get_total_size_bytes", &TimeSlice::get_total_size_bytes)
+    .def("get_sum_of_fragment_payload_sizes", &TimeSlice::get_sum_of_fragment_payload_sizes);
 } // NOLINT
 
 } // namespace python

--- a/pybindsrc/trigger_record.cpp
+++ b/pybindsrc/trigger_record.cpp
@@ -152,7 +152,9 @@ register_trigger_record(py::module& m)
         }
         return fragments;
       },
-      py::return_value_policy::reference_internal);
+      py::return_value_policy::reference_internal)
+    .def("get_total_size_bytes", &TriggerRecord::get_total_size_bytes)
+    .def("get_sum_of_fragment_payload_sizes", &TriggerRecord::get_sum_of_fragment_payload_sizes);
 } // NOLINT
 
 } // namespace python

--- a/unittest/TimeSlice_test.cxx
+++ b/unittest/TimeSlice_test.cxx
@@ -88,6 +88,10 @@ BOOST_AUTO_TEST_CASE(FragmentManipulation)
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref().size(), 1);
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref()[0]->get_size(), sizeof(FragmentHeader) + 10);
 
+  BOOST_REQUIRE_EQUAL(record.get_total_size_bytes(), sizeof(TimeSliceHeader) +
+                      sizeof(FragmentHeader) + 10);
+  BOOST_REQUIRE_EQUAL(record.get_sum_of_fragment_payload_sizes(), 10);
+
   std::vector<std::unique_ptr<Fragment>> new_vector;
   record.set_fragments(std::move(new_vector));
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref().size(), 0);

--- a/unittest/TriggerRecord_test.cxx
+++ b/unittest/TriggerRecord_test.cxx
@@ -159,6 +159,10 @@ BOOST_AUTO_TEST_CASE(FragmentManipulation)
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref().size(), 1);
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref()[0]->get_size(), sizeof(FragmentHeader) + 10);
 
+  BOOST_REQUIRE_EQUAL(record.get_total_size_bytes(), sizeof(TriggerRecordHeaderData) +
+                      2 * sizeof(ComponentRequest) + sizeof(FragmentHeader) + 10);
+  BOOST_REQUIRE_EQUAL(record.get_sum_of_fragment_payload_sizes(), 10);
+
   std::vector<std::unique_ptr<Fragment>> new_vector;
   record.set_fragments(std::move(new_vector));
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref().size(), 0);


### PR DESCRIPTION
The changes were just the addition of methods to provide the size of TriggerRecord and TimeSlice payload sizes.

These changes are one of the building blocks for other v4-to-v5 merges that we will need to do sometime (for more robust TP handling), but these changes can and should be reviewed and merged independently.

Suggested tests include the successful running of the unit tests in this package and the successful running of automated regression tests when these changes are included.
