### PR TITLE
DAPHNE ethernet fragment type

### DIFF
--- a/include/daqdataformats/FragmentHeader.hpp
+++ b/include/daqdataformats/FragmentHeader.hpp
@@ -215,6 +215,7 @@ enum class FragmentType : fragment_type_t
   kTDEEth = 15,
   kCRTBern = 16,
   kCRTGrenoble = 17,
+  kDAPHNEEth = 18,
 };
 
 /**
@@ -244,6 +245,7 @@ get_fragment_type_names()
     { FragmentType::kTDEEth, "TDEEth"},
     { FragmentType::kCRTBern, "CRTBern"},
     { FragmentType::kCRTGrenoble, "CRTGrenoble"},
+    { FragmentType::kDAPHNEEth, "DAPHNEEth"},
   };
 }
 


### PR DESCRIPTION
As the title suggests, this PR introduces the DAPHNE Ethernet type for self trigger frames.
Part of https://github.com/DUNE-DAQ/dpdklibs/issues/175