### PR TITLE
Johnfreeman/prep release merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.12)
-project(daqdataformats VERSION 3.11.0)
+project(daqdataformats VERSION 3.12.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/include/daqdataformats/FragmentHeader.hpp
+++ b/include/daqdataformats/FragmentHeader.hpp
@@ -216,6 +216,7 @@ enum class FragmentType : fragment_type_t
   kCRTBern = 16,
   kCRTGrenoble = 17,
   kDAPHNEEth = 18,
+  kDAPHNEEthStream = 19
 };
 
 /**

--- a/include/daqdataformats/FragmentHeader.hpp
+++ b/include/daqdataformats/FragmentHeader.hpp
@@ -247,6 +247,7 @@ get_fragment_type_names()
     { FragmentType::kCRTBern, "CRTBern"},
     { FragmentType::kCRTGrenoble, "CRTGrenoble"},
     { FragmentType::kDAPHNEEth, "DAPHNEEth"},
+    { FragmentType::kDAPHNEEthStream, "DAPHNEEthStream"},
   };
 }
 

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -111,6 +111,8 @@ register_fragment(py::module& m)
     .value("kTDEEth", FragmentType::kTDEEth)
     .value("kCRTBern", FragmentType::kCRTBern)
     .value("kCRTGrenoble", FragmentType::kCRTGrenoble)
+    .value("kDAPHNEEth", FragmentType::kDAPHNEEth)
+    .value("kDAPHNEEthStream", FragmentType::kDAPHNEEthStream)
     .export_values();
 
     m.def("fragment_type_to_string", &fragment_type_to_string);


### PR DESCRIPTION
With `fddaq-v5.5.0` now cut, this source branch consists of a fork of the `develop` branch with `prep-release/fddaq-v5.5.0` merged in (i.e., this will be a fast-forward merge which brings the `fddaq-v5.5.0` code into `develop`). Over the weekend a test nightly was created, `MRGFD_DEV_251213_A9`, in which all the `johnfreeman/prep_release_merged` branches were used, and if I `pip install -U . ` the `johnfreeman/prep_release_merged` branch of `drunc`, integration tests with it look fine. 


# Description

_If full decription and testing details are included on a parent issue, please link to that here._
See issue # for details

_Otherwise, please include a summary of the change and which issue is fixed (if any).
Include relevant motivation and context, including a target environment and dunedaq version if known.
Also list any dependencies that are required for this change._
Addresses issue # 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

