### PR TITLE
Johnfreeman/issue79 clang format

### DIFF
--- a/include/daqdataformats/ComponentRequest.hpp
+++ b/include/daqdataformats/ComponentRequest.hpp
@@ -41,13 +41,15 @@ struct ComponentRequest
   ComponentRequest(SourceID const& comp, timestamp_t const& wbegin, timestamp_t const& wend);
 };
 
-  std::ostream& operator<<(std::ostream& o, ComponentRequest const& cr);
+std::ostream&
+operator<<(std::ostream& o, ComponentRequest const& cr);
 
 inline ComponentRequest::ComponentRequest(SourceID const& comp, timestamp_t const& wbegin, timestamp_t const& wend)
   : component(comp)
   , window_begin(wbegin)
   , window_end(wend)
-{}
+{
+}
 
 } // namespace dunedaq::daqdataformats
 

--- a/include/daqdataformats/Fragment.hpp
+++ b/include/daqdataformats/Fragment.hpp
@@ -37,7 +37,6 @@ namespace dunedaq::daqdataformats {
 class Fragment
 {
 public:
-
   /// @brief Describes how the "existing Fragment buffer" constructor should treat the given buffer
   enum class BufferAdoptionMode
   {
@@ -98,7 +97,7 @@ public:
    */
   void set_element_id(SourceID element_id) { header_()->element_id = element_id; }
 
-  uint16_t get_detector_id() const noexcept { return header_()->detector_id; } // NOLINT
+  uint16_t get_detector_id() const noexcept { return header_()->detector_id; }                         // NOLINT
   void set_detector_id(const uint16_t& detector_id) noexcept { header_()->detector_id = detector_id; } // NOLINT
 
   /**
@@ -174,13 +173,12 @@ public:
   }
 
   ~Fragment();
-  
+
 private:
   FragmentHeader* header_() const { return static_cast<FragmentHeader*>(m_data_arr); }
   void* m_data_arr{ nullptr }; ///< Points to flat memory containing a FragmentHeader and the data payload
   bool m_alloc{ false };       ///< Whether the Fragment owns the memory pointed by m_data_arr
 };
-
 
 inline Fragment::Fragment(const std::vector<std::pair<void*, size_t>>& pieces)
 {
@@ -224,7 +222,7 @@ inline Fragment::Fragment(void* existing_fragment_buffer, BufferAdoptionMode ado
     m_alloc = true;
   } else if (adoption_mode == BufferAdoptionMode::kCopyFromBuffer) {
     auto header = reinterpret_cast<FragmentHeader*>(existing_fragment_buffer); // NOLINT
-    m_data_arr = malloc(header->size); // NOLINT
+    m_data_arr = malloc(header->size);                                         // NOLINT
     if (m_data_arr == nullptr) {
       throw std::bad_alloc();
     }
@@ -242,8 +240,8 @@ inline Fragment::~Fragment()
 inline void
 Fragment::set_header_fields(const FragmentHeader& header)
 {
-  FragmentHeader* header_ptr { header_() };
-  fragment_size_t orig_size { header_ptr->size };
+  FragmentHeader* header_ptr{ header_() };
+  fragment_size_t orig_size{ header_ptr->size };
 
   *header_ptr = header;
   header_ptr->size = orig_size;

--- a/include/daqdataformats/FragmentHeader.hpp
+++ b/include/daqdataformats/FragmentHeader.hpp
@@ -1,7 +1,7 @@
 /**
  * @file FragmentHeader.hpp  FragmentHeader struct definition
  *
- * The FragmentHeader represents the metadata describing the contents of a DUNE DAQ Fragment  
+ * The FragmentHeader represents the metadata describing the contents of a DUNE DAQ Fragment
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -33,10 +33,10 @@ struct FragmentHeader
   static constexpr uint32_t s_fragment_header_marker = 0x11112222; // NOLINT(build/unsigned)
 
   static constexpr uint32_t s_fragment_header_version = 6; // NOLINT(build/unsigned)
-  static constexpr uint32_t s_default_status_bits = 0; // NOLINT(build/unsigned)
+  static constexpr uint32_t s_default_status_bits = 0;     // NOLINT(build/unsigned)
 
   uint32_t fragment_header_marker = s_fragment_header_marker; // NOLINT(build/unsigned)
-  uint32_t version = s_fragment_header_version; // NOLINT(build/unsigned)
+  uint32_t version = s_fragment_header_version;               // NOLINT(build/unsigned)
 
   /// @brief Size of the Fragment (including header and payload)
   fragment_size_t size{ TypeDefaults::s_invalid_fragment_size }; // NOLINT(build/unsigned)
@@ -69,10 +69,9 @@ struct FragmentHeader
 
   /// @brief Component that generated the data in this Fragment
   SourceID element_id;
-
 };
 
-  /// @brief All defined status bits, with a short documentation of their meaning if non-obvious
+/// @brief All defined status bits, with a short documentation of their meaning if non-obvious
 enum class FragmentStatusBits : size_t
 {
   kLatencyBufferEmpty = 0,        ///< The latency buffer had zero occupancy when the data request was made
@@ -107,10 +106,10 @@ enum class FragmentStatusBits : size_t
   kUnassigned29 = 29,
   kUnassigned30 = 30,
   kUnassigned31 = 31,
-  kInvalid = 32                   ///< Status bit 32 and higher are not valid (status_bits is only 32 bits)
+  kInvalid = 32 ///< Status bit 32 and higher are not valid (status_bits is only 32 bits)
 };
 
-  /// @brief All defined Fragment types
+/// @brief All defined Fragment types
 enum class FragmentType : fragment_type_t
 {
   kUnknown = 0,

--- a/include/daqdataformats/SourceID.hpp
+++ b/include/daqdataformats/SourceID.hpp
@@ -46,7 +46,7 @@ struct SourceID
   };
 
   // Taking SourceID as the direct successor of GeoID which had version 1
-  static constexpr Version_t s_source_id_version = 2; 
+  static constexpr Version_t s_source_id_version = 2;
 
   static constexpr ID_t s_invalid_id = std::numeric_limits<ID_t>::max();
 
@@ -63,7 +63,8 @@ struct SourceID
   SourceID(const Subsystem& subsystem_arg, const ID_t& id_arg)
     : subsystem(subsystem_arg)
     , id(id_arg)
-  {}
+  {
+  }
 
   std::string to_string() const
   {

--- a/include/daqdataformats/TimeSlice.hpp
+++ b/include/daqdataformats/TimeSlice.hpp
@@ -104,7 +104,7 @@ public:
   TimeSlice& operator=(TimeSlice&&) = default;     ///< Default TimeSlice move assignment operator
 
   ~TimeSlice() = default; ///< TimeSlice default destructor
-  
+
 private:
   TimeSliceHeader m_header;                           ///< TimeSliceHeader object
   std::vector<std::unique_ptr<Fragment>> m_fragments; ///< Vector of unique_ptrs to Fragment objects
@@ -123,7 +123,8 @@ inline TimeSlice::TimeSlice(timeslice_number_t timeslice_number, run_number_t ru
 inline TimeSlice::TimeSlice(TimeSliceHeader const& header)
   : m_header(header)
   , m_fragments()
-{}
+{
+}
 
 } // namespace dunedaq::daqdataformats
 

--- a/include/daqdataformats/TimeSliceHeader.hpp
+++ b/include/daqdataformats/TimeSliceHeader.hpp
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 
-
 namespace dunedaq::daqdataformats {
 
 /**
@@ -35,8 +34,8 @@ struct TimeSliceHeader
   static constexpr uint32_t s_timeslice_header_version = 2; // NOLINT(build/unsigned)
 
   uint32_t timeslice_header_marker = s_timeslice_header_marker; // NOLINT(build/unsigned)
-  uint32_t version = s_timeslice_header_version; // NOLINT(build/unsigned)
-  
+  uint32_t version = s_timeslice_header_version;                // NOLINT(build/unsigned)
+
   /// @brief Slice number of this TimeSlice within the stream
   timeslice_number_t timeslice_number{ TypeDefaults::s_invalid_timeslice_number };
 
@@ -53,6 +52,5 @@ operator<<(std::ostream& o, TimeSliceHeader const& hdr);
 } // namespace dunedaq::daqdataformats
 
 #include "detail/TimeSliceHeader.hxx"
-
 
 #endif // DAQDATAFORMATS_INCLUDE_DAQDATAFORMATS_TIMESLICEHEADER_HPP_

--- a/include/daqdataformats/TriggerRecord.hpp
+++ b/include/daqdataformats/TriggerRecord.hpp
@@ -86,16 +86,17 @@ private:
   std::vector<std::unique_ptr<Fragment>> m_fragments;
 };
 
-
 inline TriggerRecord::TriggerRecord(std::vector<ComponentRequest> const& components)
   : m_header(components)
   , m_fragments()
-{}
+{
+}
 
 inline TriggerRecord::TriggerRecord(TriggerRecordHeader const& header)
   : m_header(header)
   , m_fragments()
-{}
+{
+}
 
 } // namespace dunedaq::daqdataformats
 

--- a/include/daqdataformats/TriggerRecordHeader.hpp
+++ b/include/daqdataformats/TriggerRecordHeader.hpp
@@ -1,7 +1,7 @@
 /**
  * @file TriggerRecordHeader.hpp  TriggerRecordHeader struct definition
  *
- * Conceptually, this is actually a header containing metadata about the trigger 
+ * Conceptually, this is actually a header containing metadata about the trigger
  * record followed by a collection of ComponentRequest instances
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
@@ -132,7 +132,6 @@ public:
    */
   ComponentRequest const& get_component_for_source_id(SourceID const& source_id) const;
 
-
   TriggerRecordHeader(TriggerRecordHeader const& other);
   TriggerRecordHeader& operator=(TriggerRecordHeader const& other);
 
@@ -184,7 +183,9 @@ inline TriggerRecordHeader::TriggerRecordHeader(const std::vector<ComponentReque
   TriggerRecordHeaderData header;
   header.num_requested_components = components.size();
   std::memcpy(m_data_arr, &header, sizeof(header));
-  std::memcpy(static_cast<uint8_t*>(m_data_arr) + sizeof(header), components.data(), sizeof(ComponentRequest)*components.size()); // NOLINT
+  std::memcpy(static_cast<uint8_t*>(m_data_arr) + sizeof(header),
+              components.data(),
+              sizeof(ComponentRequest) * components.size()); // NOLINT
 }
 
 inline TriggerRecordHeader::TriggerRecordHeader(void* existing_trigger_record_header_buffer, bool copy_from_buffer)
@@ -231,9 +232,8 @@ inline const ComponentRequest&
 TriggerRecordHeader::at(size_t idx) const
 {
   if (idx >= header_()->num_requested_components) {
-    throw std::range_error(
-			   std::format("Supplied ComponentRequest index {} out of range (size: {})",
-				       idx, header_()->num_requested_components));
+    throw std::range_error(std::format(
+      "Supplied ComponentRequest index {} out of range (size: {})", idx, header_()->num_requested_components));
   }
 
   // Increment header pointer by one to skip header

--- a/include/daqdataformats/TriggerRecordHeader.hpp
+++ b/include/daqdataformats/TriggerRecordHeader.hpp
@@ -183,9 +183,9 @@ inline TriggerRecordHeader::TriggerRecordHeader(const std::vector<ComponentReque
   TriggerRecordHeaderData header;
   header.num_requested_components = components.size();
   std::memcpy(m_data_arr, &header, sizeof(header));
-  std::memcpy(static_cast<uint8_t*>(m_data_arr) + sizeof(header),
+  std::memcpy(static_cast<uint8_t*>(m_data_arr) + sizeof(header), // NOLINT
               components.data(),
-              sizeof(ComponentRequest) * components.size()); // NOLINT
+              sizeof(ComponentRequest) * components.size());
 }
 
 inline TriggerRecordHeader::TriggerRecordHeader(void* existing_trigger_record_header_buffer, bool copy_from_buffer)

--- a/include/daqdataformats/TriggerRecordHeaderData.hpp
+++ b/include/daqdataformats/TriggerRecordHeaderData.hpp
@@ -30,13 +30,13 @@ struct TriggerRecordHeaderData
   static constexpr uint32_t s_trigger_record_header_magic = 0x33334444; // NOLINT(build/unsigned)
 
   static constexpr uint32_t s_trigger_record_header_version = 5; // NOLINT(build/unsigned)
-  static constexpr uint64_t s_invalid_number_components = // NOLINT(build/unsigned)
-    std::numeric_limits<uint64_t>::max();                 // NOLINT(build/unsigned)
+  static constexpr uint64_t s_invalid_number_components =        // NOLINT(build/unsigned)
+    std::numeric_limits<uint64_t>::max();                        // NOLINT(build/unsigned)
 
   static constexpr uint32_t s_default_status_bits = 0; // NOLINT(build/unsigned)
 
   uint32_t trigger_record_header_marker = s_trigger_record_header_magic; // NOLINT(build/unsigned)
-  uint32_t version = s_trigger_record_header_version; // NOLINT(build/unsigned)
+  uint32_t version = s_trigger_record_header_version;                    // NOLINT(build/unsigned)
 
   trigger_number_t trigger_number{ TypeDefaults::s_invalid_trigger_number };
 
@@ -64,11 +64,12 @@ struct TriggerRecordHeaderData
   SourceID element_id;
 };
 
-/// @brief This enumeration lists all defined status bits, as well as a short documentation of their meaning when not obvious
+/// @brief This enumeration lists all defined status bits, as well as a short documentation of their meaning when not
+/// obvious
 enum class TriggerRecordStatusBits : size_t
 {
-  kIncomplete = 0,    ///< Indicates a trigger record that is missing requested components
-  kMismatch = 1,      ///< We have as many fragments as requested but they do not match the requested components
+  kIncomplete = 0, ///< Indicates a trigger record that is missing requested components
+  kMismatch = 1,   ///< We have as many fragments as requested but they do not match the requested components
   kUnassigned2 = 2,
   kUnassigned3 = 3,
   kUnassigned4 = 4,
@@ -99,7 +100,7 @@ enum class TriggerRecordStatusBits : size_t
   kUnassigned29 = 29,
   kUnassigned30 = 30,
   kUnassigned31 = 31,
-  kInvalid = 32       ///< Status bit 32 and higher are not valid (status_bits is only 32 bits)
+  kInvalid = 32 ///< Status bit 32 and higher are not valid (status_bits is only 32 bits)
 };
 
 std::ostream&

--- a/include/daqdataformats/Types.hpp
+++ b/include/daqdataformats/Types.hpp
@@ -14,15 +14,15 @@
 
 namespace dunedaq::daqdataformats {
 
-using run_number_t = uint32_t; // NOLINT(build/unsigned)
+using run_number_t = uint32_t;     // NOLINT(build/unsigned)
 using trigger_number_t = uint64_t; // NOLINT(build/unsigned)
 
-  /// @brief Type used to represent Fragment type ID
+/// @brief Type used to represent Fragment type ID
 using fragment_type_t = uint32_t; // NOLINT(build/unsigned)
 
 using fragment_size_t = uint64_t; // NOLINT(build/unsigned)
 
-  /// @brief Type used to represent DUNE timing system timestamps
+/// @brief Type used to represent DUNE timing system timestamps
 using timestamp_t = uint64_t;     // NOLINT(build/unsigned)
 using timestamp_diff_t = int64_t; ///< Used to represent differences between timestamps
 
@@ -44,24 +44,17 @@ using timeslice_number_t = uint64_t; // NOLINT(build/unsigned)
  */
 struct TypeDefaults
 {
-  static constexpr run_number_t s_invalid_run_number =
-    std::numeric_limits<run_number_t>::max();
-  static constexpr trigger_number_t s_invalid_trigger_number =
-    std::numeric_limits<trigger_number_t>::max();
-  static constexpr fragment_type_t s_invalid_fragment_type =
-    std::numeric_limits<fragment_type_t>::max();
+  static constexpr run_number_t s_invalid_run_number = std::numeric_limits<run_number_t>::max();
+  static constexpr trigger_number_t s_invalid_trigger_number = std::numeric_limits<trigger_number_t>::max();
+  static constexpr fragment_type_t s_invalid_fragment_type = std::numeric_limits<fragment_type_t>::max();
   static constexpr fragment_size_t s_invalid_fragment_size =
     0; ///< Invalid size for a Fragment (as FragmentHeader is counted as well)
   static constexpr timestamp_t s_invalid_timestamp = std::numeric_limits<timestamp_t>::max();
-  static constexpr timestamp_diff_t s_invalid_timestamp_diff =
-    std::numeric_limits<timestamp_diff_t>::max();
+  static constexpr timestamp_diff_t s_invalid_timestamp_diff = std::numeric_limits<timestamp_diff_t>::max();
 
-  static constexpr trigger_type_t s_invalid_trigger_type =
-    std::numeric_limits<trigger_type_t>::max();
-  static constexpr sequence_number_t s_invalid_sequence_number =
-    std::numeric_limits<sequence_number_t>::max();
-  static constexpr timeslice_number_t s_invalid_timeslice_number =
-    std::numeric_limits<timeslice_number_t>::max();
+  static constexpr trigger_type_t s_invalid_trigger_type = std::numeric_limits<trigger_type_t>::max();
+  static constexpr sequence_number_t s_invalid_sequence_number = std::numeric_limits<sequence_number_t>::max();
+  static constexpr timeslice_number_t s_invalid_timeslice_number = std::numeric_limits<timeslice_number_t>::max();
 };
 
 } // namespace dunedaq::daqdataformats

--- a/include/daqdataformats/detail/ComponentRequest.hxx
+++ b/include/daqdataformats/detail/ComponentRequest.hxx
@@ -1,13 +1,16 @@
 
 namespace dunedaq::daqdataformats {
 
+static_assert(std::is_trivially_copyable<ComponentRequest>::value,
+              "ComponentRequest isn't trivially copyable and can't be safely std::memcpy'd");
 
-static_assert(std::is_trivially_copyable<ComponentRequest>::value, "ComponentRequest isn't trivially copyable and can't be safely std::memcpy'd");
-  
-static_assert(std::is_standard_layout<ComponentRequest>::value, "ComponentRequest isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::is_standard_layout<ComponentRequest>::value,
+              "ComponentRequest isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
 
-static_assert(ComponentRequest::s_component_request_version == 2, "This is intentionally designed to tell the developer to update the static_assert checks (including this one) when the version is bumped");
-  
+static_assert(ComponentRequest::s_component_request_version == 2,
+              "This is intentionally designed to tell the developer to update the static_assert checks (including this "
+              "one) when the version is bumped");
+
 static_assert(sizeof(ComponentRequest) == 32, "ComponentRequest struct size different than expected!");
 static_assert(offsetof(ComponentRequest, version) == 0, "ComponentRequest version field not at expected offset");
 static_assert(offsetof(ComponentRequest, unused) == 4, "ComponentRequest unused field not at expected offset");
@@ -16,10 +19,10 @@ static_assert(offsetof(ComponentRequest, window_begin) == 16,
               "ComponentRequest window_begin field not at expected offset");
 static_assert(offsetof(ComponentRequest, window_end) == 24, "ComponentRequest window_end field not at expected offset");
 
-  inline std::ostream&
-  operator<<(std::ostream& o, ComponentRequest const& cr)
-  {
-    return o << cr.component << ", begin: " << cr.window_begin << ", end: " << cr.window_end;
-  }
+inline std::ostream&
+operator<<(std::ostream& o, ComponentRequest const& cr)
+{
+  return o << cr.component << ", begin: " << cr.window_begin << ", end: " << cr.window_end;
+}
 
 } // namespace dunedaq::daqdataformats

--- a/include/daqdataformats/detail/FragmentHeader.hxx
+++ b/include/daqdataformats/detail/FragmentHeader.hxx
@@ -1,10 +1,12 @@
 
 namespace dunedaq::daqdataformats {
 
-static_assert(std::is_trivially_copyable<FragmentHeader>::value, "FragmentHeader isn't trivially copyable and can't be safely std::memcpy'd");
-  
-static_assert(std::is_standard_layout<FragmentHeader>::value, "FragmentHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
-  
+static_assert(std::is_trivially_copyable<FragmentHeader>::value,
+              "FragmentHeader isn't trivially copyable and can't be safely std::memcpy'd");
+
+static_assert(std::is_standard_layout<FragmentHeader>::value,
+              "FragmentHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+
 static_assert(FragmentHeader::s_fragment_header_version == 6,
               "This is intentionally designed to tell the developer to update the static_assert checks (including this "
               "one) when the version is bumped");
@@ -49,7 +51,7 @@ string_to_fragment_type(const std::string& name)
   }
   return FragmentType::kUnknown;
 }
-  
+
 inline std::ostream&
 operator<<(std::ostream& o, FragmentHeader const& hdr)
 {
@@ -61,5 +63,5 @@ operator<<(std::ostream& o, FragmentHeader const& hdr)
            << "sequence_number: " << hdr.sequence_number << ", " << "detector_id: " << hdr.detector_id << ", "
            << "element_id: " << hdr.element_id;
 }
-  
+
 } // namespace dunedaq::daqdataformats

--- a/include/daqdataformats/detail/SourceID.hxx
+++ b/include/daqdataformats/detail/SourceID.hxx
@@ -1,9 +1,11 @@
 
 namespace dunedaq::daqdataformats {
 
-  static_assert(std::is_trivially_copyable<SourceID>::value, "SourceID isn't trivially copyable and can't be safely std::memcpy'd");
-  
-  static_assert(std::is_standard_layout<SourceID>::value, "SourceID isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::is_trivially_copyable<SourceID>::value,
+              "SourceID isn't trivially copyable and can't be safely std::memcpy'd");
+
+static_assert(std::is_standard_layout<SourceID>::value,
+              "SourceID isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
 
 static_assert(SourceID::s_source_id_version == 2,
               "This is intentionally designed to tell the developer to update the static_assert checks (including this "
@@ -39,7 +41,7 @@ operator>>(std::istream& is, SourceID::Subsystem& t)
 inline std::istream&
 operator>>(std::istream& is, SourceID& source_id)
 {
-  std::string tmp ;
+  std::string tmp;
   is >> tmp >> source_id.subsystem >> tmp >> source_id.id; // Eat last three tokens, e.g. "-> (314, 159)"
 
   return is;

--- a/include/daqdataformats/detail/TimeSliceHeader.hxx
+++ b/include/daqdataformats/detail/TimeSliceHeader.hxx
@@ -1,21 +1,23 @@
 
 namespace dunedaq::daqdataformats {
 
-  static_assert(std::is_trivially_copyable<TimeSliceHeader>::value, "TimeSliceHeader isn't trivially copyable and can't be safely std::memcpy'd");
-  
-  static_assert(std::is_standard_layout<TimeSliceHeader>::value, "TimeSliceHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
-  static_assert(TimeSliceHeader::s_timeslice_header_version == 2,
+static_assert(std::is_trivially_copyable<TimeSliceHeader>::value,
+              "TimeSliceHeader isn't trivially copyable and can't be safely std::memcpy'd");
+
+static_assert(std::is_standard_layout<TimeSliceHeader>::value,
+              "TimeSliceHeader isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(TimeSliceHeader::s_timeslice_header_version == 2,
               "This is intentionally designed to tell the developer to update the static_assert checks (including this "
               "one) when the version is bumped");
-  static_assert(sizeof(TimeSliceHeader) == 32, "TimeSliceHeader struct size different than expected!");
-  static_assert(offsetof(TimeSliceHeader, timeslice_header_marker) == 0,
-		"TimeSliceHeader timeslice_header_marker field not at expected offset!");
-  static_assert(offsetof(TimeSliceHeader, version) == 4, "TimeSliceHeader version field not at expected offset!");
-  static_assert(offsetof(TimeSliceHeader, timeslice_number) == 8,
-		"TimeSliceHeader timeslice_number field not at expected offset!");
-  static_assert(offsetof(TimeSliceHeader, run_number) == 16, "TimeSliceHeader run_number field not at expected offset!");
-  static_assert(offsetof(TimeSliceHeader, unused) == 20, "TimeSliceHeader unused field not at expected offset!");
-  static_assert(offsetof(TimeSliceHeader, element_id) == 24, "TimeSliceHeader source_id field not at expected offset!");
+static_assert(sizeof(TimeSliceHeader) == 32, "TimeSliceHeader struct size different than expected!");
+static_assert(offsetof(TimeSliceHeader, timeslice_header_marker) == 0,
+              "TimeSliceHeader timeslice_header_marker field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, version) == 4, "TimeSliceHeader version field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, timeslice_number) == 8,
+              "TimeSliceHeader timeslice_number field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, run_number) == 16, "TimeSliceHeader run_number field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, unused) == 20, "TimeSliceHeader unused field not at expected offset!");
+static_assert(offsetof(TimeSliceHeader, element_id) == 24, "TimeSliceHeader source_id field not at expected offset!");
 
 inline std::ostream&
 operator<<(std::ostream& o, TimeSliceHeader const& hdr)
@@ -27,5 +29,5 @@ operator<<(std::ostream& o, TimeSliceHeader const& hdr)
            << "run_number: " << hdr.run_number << ", "
            << "element_id: { " << hdr.element_id << " }";
 }
-  
+
 } // namespace dunedaq::daqdataformats

--- a/include/daqdataformats/detail/TriggerRecordHeaderData.hxx
+++ b/include/daqdataformats/detail/TriggerRecordHeaderData.hxx
@@ -1,11 +1,13 @@
 
 namespace dunedaq::daqdataformats {
 
-  static_assert(std::is_trivially_copyable<TriggerRecordHeaderData>::value, "TriggerRecordHeaderData isn't trivially copyable and can't be safely std::memcpy'd");
-  
-  static_assert(std::is_standard_layout<TriggerRecordHeaderData>::value, "TriggerRecordHeaderData isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+static_assert(std::is_trivially_copyable<TriggerRecordHeaderData>::value,
+              "TriggerRecordHeaderData isn't trivially copyable and can't be safely std::memcpy'd");
 
-  
+static_assert(
+  std::is_standard_layout<TriggerRecordHeaderData>::value,
+  "TriggerRecordHeaderData isn't standard layout; reinterpret_cast and offsetof can't safely be used with it");
+
 static_assert(TriggerRecordHeaderData::s_trigger_record_header_version == 5,
               "This is intentionally designed to tell the developer to update the static_assert checks (including this "
               "one) when the version is bumped");
@@ -52,5 +54,4 @@ operator<<(std::ostream& o, TriggerRecordHeaderData const& hdr)
            << ", " << "element_id: { " << hdr.element_id << " }";
 }
 
-  
 } // namespace dunedaq::daqdataformats

--- a/pybindsrc/component_request.cpp
+++ b/pybindsrc/component_request.cpp
@@ -24,16 +24,18 @@ register_component_request(py::module& m)
   py::class_<ComponentRequest>(m, "ComponentRequest")
     .def(py::init())
     .def(py::init<SourceID const&, timestamp_t const&, timestamp_t const&>())
-    .def("__str__", [](const ComponentRequest& cr) {
-      std::ostringstream oss;
-      oss << cr;
-      return oss.str();
-    })
-    .def("__repr__", [](const ComponentRequest& cr) {
-      std::ostringstream oss;
-      oss << "<daqdataformats::ComponentRequest " << cr << ">";
-      return oss.str();
-    })
+    .def("__str__",
+         [](const ComponentRequest& cr) {
+           std::ostringstream oss;
+           oss << cr;
+           return oss.str();
+         })
+    .def("__repr__",
+         [](const ComponentRequest& cr) {
+           std::ostringstream oss;
+           oss << "<daqdataformats::ComponentRequest " << cr << ">";
+           return oss.str();
+         })
     .def_readonly_static("s_component_request_version", &ComponentRequest::s_component_request_version)
     .def_readonly("version", &ComponentRequest::version)
     .def_readonly("unused", &ComponentRequest::unused)

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -44,8 +44,8 @@ register_fragment(py::module& m)
     .def(
       "get_data",
       [](Fragment& self, size_t offset) {
-        return static_cast<void*>(static_cast<char*>(self.get_data()) + offset);
-      }, // NOLINT
+        return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); // NOLINT
+      },
       "offset"_a = 0,
       py::return_value_policy::reference_internal)
     .def(

--- a/pybindsrc/fragment.cpp
+++ b/pybindsrc/fragment.cpp
@@ -43,7 +43,9 @@ register_fragment(py::module& m)
     .def("get_data_size", &Fragment::get_data_size)
     .def(
       "get_data",
-      [](Fragment& self, size_t offset) { return static_cast<void*>(static_cast<char*>(self.get_data()) + offset); }, // NOLINT
+      [](Fragment& self, size_t offset) {
+        return static_cast<void*>(static_cast<char*>(self.get_data()) + offset);
+      }, // NOLINT
       "offset"_a = 0,
       py::return_value_policy::reference_internal)
     .def(
@@ -98,11 +100,12 @@ register_fragment(py::module& m)
     .def_property_readonly("element_id", [](const FragmentHeader& self) -> SourceID { return self.element_id; })
 
     .def_static("sizeof", []() { return sizeof(FragmentHeader); })
-    .def("__str__", [](const FragmentHeader& hdr) {
-      std::ostringstream oss;
-      oss << hdr;
-      return oss.str();
-    })
+    .def("__str__",
+         [](const FragmentHeader& hdr) {
+           std::ostringstream oss;
+           oss << hdr;
+           return oss.str();
+         })
     .def("__repr__", [](const FragmentHeader& hdr) {
       std::ostringstream oss;
       oss << "<daqdataformats::FragmentHeader " << hdr << ">";

--- a/pybindsrc/sourceid.cpp
+++ b/pybindsrc/sourceid.cpp
@@ -27,27 +27,25 @@ register_sourceid(py::module& m)
   py_sourceid.def(py::self < py::self)
     .def(py::self == py::self)
     .def(py::self != py::self)
-    .def("__hash__", [](const SourceID& self) {
-      return py::hash(py::make_tuple(static_cast<uint32_t>(self.subsystem), self.id)); // NOLINT(build/unsigned)
-    })
-    .def_property_readonly_static("s_source_id_version",
-                                  [](const py::object&) -> SourceID::Version_t {
-                                    return SourceID::s_source_id_version;
-                                  })
+    .def("__hash__",
+         [](const SourceID& self) {
+           return py::hash(py::make_tuple(static_cast<uint32_t>(self.subsystem), self.id)); // NOLINT(build/unsigned)
+         })
+    .def_property_readonly_static(
+      "s_source_id_version", [](const py::object&) -> SourceID::Version_t { return SourceID::s_source_id_version; })
     .def_property_readonly_static("s_invalid_id",
-                                  [](const py::object&) -> SourceID::ID_t {
-                                    return SourceID::s_invalid_id;
-                                  })
-    .def("__str__", [](const SourceID& gid) {
-    std::ostringstream oss;
-    oss << gid;
-    return oss.str();
-  })
+                                  [](const py::object&) -> SourceID::ID_t { return SourceID::s_invalid_id; })
+    .def("__str__",
+         [](const SourceID& gid) {
+           std::ostringstream oss;
+           oss << gid;
+           return oss.str();
+         })
     .def("__repr__", [](const SourceID& gid) {
-    std::ostringstream oss;
-    oss << "<daqdataformats::SourceID " << gid << ">";
-    return oss.str();
-  });
+      std::ostringstream oss;
+      oss << "<daqdataformats::SourceID " << gid << ">";
+      return oss.str();
+    });
 
   py::enum_<SourceID::Subsystem>(py_sourceid, "Subsystem")
     .value("kUnknown", SourceID::Subsystem::kUnknown)
@@ -63,8 +61,8 @@ register_sourceid(py::module& m)
 
   py_sourceid.def("subsystem_to_string", &SourceID::subsystem_to_string)
     .def("string_to_subsystem", &SourceID::string_to_subsystem)
-      .def("to_string", &SourceID::to_string)
-      .def("is_in_valid_state", &SourceID::is_in_valid_state);
+    .def("to_string", &SourceID::to_string)
+    .def("is_in_valid_state", &SourceID::is_in_valid_state);
 }
 
 } // namespace dunedaq::daqdataformats::python

--- a/pybindsrc/time_slice.cpp
+++ b/pybindsrc/time_slice.cpp
@@ -43,11 +43,12 @@ register_timeslice(py::module& m)
                            [](const TimeSliceHeader& self) -> timeslice_number_t { return self.timeslice_number; })
     .def_property_readonly("run_number", [](const TimeSliceHeader& self) -> run_number_t { return self.run_number; })
     .def_property_readonly("element_id", [](const TimeSliceHeader& self) -> SourceID { return self.element_id; })
-    .def("__str__", [](const TimeSliceHeader& hdr) {
-      std::ostringstream oss;
-      oss << hdr;
-      return oss.str();
-    })
+    .def("__str__",
+         [](const TimeSliceHeader& hdr) {
+           std::ostringstream oss;
+           oss << hdr;
+           return oss.str();
+         })
     .def("__repr__", [](const TimeSliceHeader& hdr) {
       std::ostringstream oss;
       oss << "<daqdataformats::TimeSliceHeader " << hdr << ">";

--- a/pybindsrc/trigger_record.cpp
+++ b/pybindsrc/trigger_record.cpp
@@ -51,7 +51,8 @@ register_trigger_record(py::module& m)
     .def(
       "get_storage_location", &TriggerRecordHeader::get_storage_location, py::return_value_policy::reference_internal)
     .def("get_element_id", &TriggerRecordHeader::get_element_id)
-    .def("get_component_for_source_id", &TriggerRecordHeader::get_component_for_source_id,
+    .def("get_component_for_source_id",
+         &TriggerRecordHeader::get_component_for_source_id,
          py::return_value_policy::reference_internal)
     .def("at", &TriggerRecordHeader::at)
     .def("__getitem__", &TriggerRecordHeader::at, py::return_value_policy::reference_internal);
@@ -97,16 +98,17 @@ register_trigger_record(py::module& m)
                            [](const TriggerRecordHeaderData& self) -> trigger_type_t { return self.trigger_type; })
     .def_property_readonly(
       "sequence_number", [](const TriggerRecordHeaderData& self) -> sequence_number_t { return self.sequence_number; })
-    .def_property_readonly("max_sequence_number", [](const TriggerRecordHeaderData& self) -> sequence_number_t {
-      return self.max_sequence_number;
-    })
+    .def_property_readonly(
+      "max_sequence_number",
+      [](const TriggerRecordHeaderData& self) -> sequence_number_t { return self.max_sequence_number; })
     .def_property_readonly("element_id",
                            [](const TriggerRecordHeaderData& self) -> SourceID { return self.element_id; })
-    .def("__str__", [](const TriggerRecordHeaderData& hdr) {
-      std::ostringstream oss;
-      oss << hdr;
-      return oss.str();
-    })
+    .def("__str__",
+         [](const TriggerRecordHeaderData& hdr) {
+           std::ostringstream oss;
+           oss << hdr;
+           return oss.str();
+         })
     .def("__repr__", [](const TriggerRecordHeaderData& hdr) {
       std::ostringstream oss;
       oss << "<daqdataformats::TriggerRecordHeaderData " << hdr << ">";

--- a/unittest/ComponentRequest_test.cxx
+++ b/unittest/ComponentRequest_test.cxx
@@ -57,7 +57,6 @@ BOOST_AUTO_TEST_CASE(StreamOperator)
   BOOST_REQUIRE(pos != std::string::npos);
   pos = output.find("begin: 3,");
   BOOST_REQUIRE(pos != std::string::npos);
-
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/FragmentHeader_test.cxx
+++ b/unittest/FragmentHeader_test.cxx
@@ -31,7 +31,9 @@ BOOST_AUTO_TEST_CASE(FragmentTypeConversion)
   auto type_map = get_fragment_type_names();
   // sanity check
   for (auto& type_pair : type_map) {
-    BOOST_TEST_MESSAGE("Fragment type" << int(type_pair.first) << " " << type_pair.second << " with converters: " << int(string_to_fragment_type(type_pair.second)) << " " << fragment_type_to_string(type_pair.first));
+    BOOST_TEST_MESSAGE("Fragment type" << int(type_pair.first) << " " << type_pair.second
+                                       << " with converters: " << int(string_to_fragment_type(type_pair.second)) << " "
+                                       << fragment_type_to_string(type_pair.first));
     BOOST_REQUIRE_EQUAL(static_cast<fragment_type_t>(string_to_fragment_type(type_pair.second)),
                         static_cast<fragment_type_t>(type_pair.first));
     BOOST_REQUIRE_EQUAL(fragment_type_to_string(type_pair.first), type_pair.second);

--- a/unittest/Fragment_test.cxx
+++ b/unittest/Fragment_test.cxx
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(BadConstructors)
 
   auto bufsize = 10;
   std::vector<uint8_t> buf1(bufsize); // NOLINT(build/unsigned)
-  fragment_ptr = std::make_unique<Fragment>( buf1.data(), buf1.size() );
+  fragment_ptr = std::make_unique<Fragment>(buf1.data(), buf1.size());
   BOOST_REQUIRE_EQUAL(fragment_ptr->get_size(), sizeof(FragmentHeader) + bufsize);
 }
 
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(ExistingFragmentConstructor)
   auto frag = malloc(sizeof(FragmentHeader) + 4); // NOLINT
   memcpy(frag, &header, sizeof(FragmentHeader));
 
-  uint8_t one = 1, two = 2, three = 3, four = 4; // NOLINT
+  uint8_t one = 1, two = 2, three = 3, four = 4;                               // NOLINT
   memcpy(static_cast<uint8_t*>(frag) + sizeof(FragmentHeader), &one, 1);       // NOLINT
   memcpy(static_cast<uint8_t*>(frag) + sizeof(FragmentHeader) + 1, &two, 1);   // NOLINT
   memcpy(static_cast<uint8_t*>(frag) + sizeof(FragmentHeader) + 2, &three, 1); // NOLINT
@@ -103,8 +103,8 @@ BOOST_AUTO_TEST_CASE(ExistingFragmentConstructor)
 
   free(frag); // Should not cause errors // NOLINT
 
-  frag = malloc(sizeof(FragmentHeader) + 4); // NOLINT
-  memcpy(frag, &header, sizeof(FragmentHeader)); // NOLINT
+  frag = malloc(sizeof(FragmentHeader) + 4);                                   // NOLINT
+  memcpy(frag, &header, sizeof(FragmentHeader));                               // NOLINT
   memcpy(static_cast<uint8_t*>(frag) + sizeof(FragmentHeader), &four, 1);      // NOLINT
   memcpy(static_cast<uint8_t*>(frag) + sizeof(FragmentHeader) + 1, &three, 1); // NOLINT
   memcpy(static_cast<uint8_t*>(frag) + sizeof(FragmentHeader) + 2, &two, 1);   // NOLINT
@@ -171,9 +171,9 @@ BOOST_AUTO_TEST_CASE(BadExistingFragmentConstructor)
 
 BOOST_AUTO_TEST_CASE(MoveConstructor)
 {
-  size_t bufsize {10};
+  size_t bufsize{ 10 };
   auto buf1 = malloc(bufsize); // NOLINT
-  auto single_frag = new Fragment(buf1, bufsize); 
+  auto single_frag = new Fragment(buf1, bufsize);
   BOOST_REQUIRE_EQUAL(single_frag->get_size(), sizeof(FragmentHeader) + bufsize);
 
   Fragment another_frag(std::move(*single_frag));
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(MoveConstructor)
 
 BOOST_AUTO_TEST_CASE(MoveAssignment)
 {
-  size_t bufsize {10};
+  size_t bufsize{ 10 };
   auto buf1 = malloc(bufsize); // NOLINT
   auto single_frag = new Fragment(buf1, bufsize);
   BOOST_REQUIRE_EQUAL(single_frag->get_size(), sizeof(FragmentHeader) + bufsize);

--- a/unittest/SourceID_test.cxx
+++ b/unittest/SourceID_test.cxx
@@ -66,7 +66,8 @@ BOOST_AUTO_TEST_CASE(StreamOperator)
   // SourceID test2;
   // istr >> test2;
   // BOOST_TEST_MESSAGE("Looks like the output-from-the-input is \"" << test2) << "\"";
-  // BOOST_REQUIRE_EQUAL(test.subsystem, test2.subsystem); // Recall that output was generated from streaming out a  SourceID instance
+  // BOOST_REQUIRE_EQUAL(test.subsystem, test2.subsystem); // Recall that output was generated from streaming out a
+  // SourceID instance
 
   // SourceID::Subsystem cat{ SourceID::Subsystem::kTrigger };
   // std::ostringstream cat_ostr;

--- a/unittest/TimeSlice_test.cxx
+++ b/unittest/TimeSlice_test.cxx
@@ -88,8 +88,7 @@ BOOST_AUTO_TEST_CASE(FragmentManipulation)
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref().size(), 1);
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref()[0]->get_size(), sizeof(FragmentHeader) + 10);
 
-  BOOST_REQUIRE_EQUAL(record.get_total_size_bytes(), sizeof(TimeSliceHeader) +
-                      sizeof(FragmentHeader) + 10);
+  BOOST_REQUIRE_EQUAL(record.get_total_size_bytes(), sizeof(TimeSliceHeader) + sizeof(FragmentHeader) + 10);
   BOOST_REQUIRE_EQUAL(record.get_sum_of_fragment_payload_sizes(), 10);
 
   std::vector<std::unique_ptr<Fragment>> new_vector;

--- a/unittest/TriggerRecordHeader_test.cxx
+++ b/unittest/TriggerRecordHeader_test.cxx
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(BadConstructors)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wrestrict"
   BOOST_REQUIRE_EXCEPTION(
-			  TriggerRecordHeader header_inst = bad_header, std::bad_alloc, [&](std::bad_alloc) { return true; }); // NOLINT
+    TriggerRecordHeader header_inst = bad_header, std::bad_alloc, [&](std::bad_alloc) { return true; }); // NOLINT
 #pragma GCC diagnostic pop
 
   free(hdr); // NOLINT

--- a/unittest/TriggerRecord_test.cxx
+++ b/unittest/TriggerRecord_test.cxx
@@ -158,9 +158,8 @@ BOOST_AUTO_TEST_CASE(FragmentManipulation)
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref().size(), 1);
   BOOST_REQUIRE_EQUAL(record.get_fragments_ref()[0]->get_size(), sizeof(FragmentHeader) + 10);
 
-  BOOST_REQUIRE_EQUAL(record.get_total_size_bytes(), sizeof(TriggerRecordHeaderData) +
-                      2 * sizeof(ComponentRequest) + sizeof(FragmentHeader) + 10);
-
+  BOOST_REQUIRE_EQUAL(record.get_total_size_bytes(),
+                      sizeof(TriggerRecordHeaderData) + 2 * sizeof(ComponentRequest) + sizeof(FragmentHeader) + 10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Description

This is a whitespace change, courtesy of `dbt-clang-format.sh`; it can be considered part of Issue #79. Note that along with whitespace change I did need to move two `// NOLINT` directives which had been shifted to the "wrong" physical line. 

_Please also include instructions for how a reviewer can test your changes._


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

